### PR TITLE
Add a closeOutbound func to GRPCStreamStateMachine and remove endStream param from send(message:)

### DIFF
--- a/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
@@ -153,7 +153,7 @@ extension GRPCServerStreamHandler {
 
     case .message(let message):
       do {
-        try self.stateMachine.send(message: message, endStream: false)
+        try self.stateMachine.send(message: message)
         // TODO: move the promise handling into the state machine
         promise?.succeed()
       } catch {

--- a/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
+++ b/Sources/GRPCHTTP2Core/Server/GRPCServerStreamHandler.swift
@@ -63,7 +63,7 @@ extension GRPCServerStreamHandler {
       switch frameData.data {
       case .byteBuffer(let buffer):
         do {
-          try self.stateMachine.receive(message: buffer, endStream: endStream)
+          try self.stateMachine.receive(buffer: buffer, endStream: endStream)
           loop: while true {
             switch self.stateMachine.nextInboundMessage() {
             case .receiveMessage(let message):
@@ -86,7 +86,7 @@ extension GRPCServerStreamHandler {
     case .headers(let headers):
       do {
         let action = try self.stateMachine.receive(
-          metadata: headers.headers,
+          headers: headers.headers,
           endStream: headers.endStream
         )
         switch action {


### PR DESCRIPTION
This change is necessary to decouple the sending messages from closing the outbound side of the channel.
It will simplify the implementation of the `GRPCClientStreamHandler`.