### PR TITLE
Change `StreamingClientResponse/messages` to be throwing

### DIFF
--- a/Tests/GRPCCoreTests/Call/Client/ClientResponseTests.swift
+++ b/Tests/GRPCCoreTests/Call/Client/ClientResponseTests.swift
@@ -102,7 +102,7 @@ final class ClientResponseTests: XCTestCase {
 
     XCTAssertEqual(response.metadata, [:])
     await XCTAssertThrowsRPCErrorAsync {
-      try await response.messages.collect()
+      try response.messages
     } errorHandler: {
       XCTAssertEqual($0, error)
     }

--- a/Tests/GRPCCoreTests/GRPCClientTests.swift
+++ b/Tests/GRPCCoreTests/GRPCClientTests.swift
@@ -89,7 +89,7 @@ final class GRPCClientTests: XCTestCase {
         deserializer: IdentityDeserializer(),
         options: .defaults
       ) { response in
-        var responseParts = response.messages.makeAsyncIterator()
+        var responseParts = try response.messages.makeAsyncIterator()
         for byte in [3, 1, 4, 1, 5] as [UInt8] {
           let message = try await responseParts.next()
           XCTAssertEqual(message, [byte])
@@ -111,7 +111,7 @@ final class GRPCClientTests: XCTestCase {
         deserializer: IdentityDeserializer(),
         options: .defaults
       ) { response in
-        var responseParts = response.messages.makeAsyncIterator()
+        var responseParts = try response.messages.makeAsyncIterator()
         for byte in [3, 1, 4, 1, 5] as [UInt8] {
           let message = try await responseParts.next()
           XCTAssertEqual(message, [byte])


### PR DESCRIPTION
The `StreamingClientResponse/accepted` docs say:

> The `success` case indicates the RPC was accepted by the server for processing, however, the RPC may still fail by throwing an error from its `messages` sequence. The `failure` case indicates that the RPC was rejected by the server.

However, in the shorthand `StreamingClientResponse/messages`, we _do not_ throw in the `failure` case. Rather, we always return a sequence that throws.

It's a small semantic difference, but I believe we should stick to the premise that the sequence will throw _only if_ the RPC was processed but failed. If the RPC was rejected, I believe we should throw before returning the sequence.